### PR TITLE
a fix and a url update

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-22.6
+resolver: lts-22.43
 extra-deps:
 # WARNING: Changing the hoogle version causes stackage-server-cron to regenerate
 # Hoogle databases FOR EVERY SNAPSHOT, EVER. Usually, that's ok! But don't
@@ -13,7 +13,7 @@ extra-deps:
 # waste. (4) Stackage's Hoogle search will be unavailable until the new
 # databases have been generated.
 - hoogle-5.0.18.4@sha256:1372458e97dff541fcda099236af7936bf93ee6b8c5d15695ee6d9426dff5eed,3171
-- safe-0.3.20@sha256:7813ad56161f57d5162a924de5597d454162a2faed06be6e268b37bb5c19d48d,2312
+# for patched pantry-0.5.7
 - Cabal-3.8.1.0@sha256:77121d8e1aff14a0fd95684b751599db78a7dd26d55862d9fcef27c88b193e9d,12609
 - Cabal-syntax-3.8.1.0@sha256:ed2d937ba6c6a20b75850349eedd41374885fc42369ef152d69e2ba70f44f593,7620
 - git: https://github.com/commercialhaskell/pantry.git

--- a/templates/blog-post.hamlet
+++ b/templates/blog-post.hamlet
@@ -16,4 +16,4 @@
           <a href=@?{addPreview $ BlogPostR (postYear post') (postMonth post') (postSlug post')}>
             #{postTitle post'}
           &mdash;
-          <abbr title=#{show $ postTime post}>#{dateDiff now (utctDay $ postTime post')}
+          <abbr title=#{show $ postTime post'}>#{dateDiff now (utctDay $ postTime post')}

--- a/templates/package.hamlet
+++ b/templates/package.hamlet
@@ -47,7 +47,7 @@ $newline never
             $if isNothing msppi
                 <p .add-to-nightly>
                     This package is not currently in any snapshots. If you're interested in using it, we recommend #
-                    <a href="https://github.com/fpco/stackage/#add-your-package">adding it to Stackage Nightly
+                    <a href="https://github.com/commercialhaskell/stackage/#add-your-package">adding it to Stackage Nightly
                     . Doing so will make builds more reliable, and allow stackage.org to host generated Haddocks.
             $else
                 <p>


### PR DESCRIPTION
- fix dates in blog archive list to not be for current displayed post
- update url to stackage readme section on adding package
- bump to final lts-22.43