### PR TITLE
add snapshot diff previous link and time to snapshot date

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Server for stable, curated Haskell package sets
 
-This repo is part of the [Stackage project](https://github.com/fpco/stackage),
+This repo is part of the [Stackage project](https://github.com/commercialhaskell/stackage),
 and the live server can be viewed at https://www.stackage.org.
 
 ## Building locally

--- a/src/Application.hs
+++ b/src/Application.hs
@@ -138,7 +138,7 @@ withFoundation appLogFunc appSettings inner = do
             then do
                 fp <- runSimpleApp $ getStackageContentDir "."
                 gitRepoDev fp loadWebsiteContent
-            else gitRepo "https://github.com/fpco/stackage-content.git" "master" loadWebsiteContent
+            else gitRepo "https://github.com/commercialhaskell/stackage-content.git" "master" loadWebsiteContent
     let runContentUpdates =
             Concurrently $
             forever $

--- a/src/Handler/BuildPlan.hs
+++ b/src/Handler/BuildPlan.hs
@@ -6,7 +6,7 @@ import Import
 
 getBuildPlanR :: SnapName -> Handler TypedContent
 getBuildPlanR _slug = track "Handler.BuildPlan.getBuildPlanR" $ do
-    error "temporarily disabled, please open on issue on https://github.com/fpco/stackage-server/issues/ if you need it"
+    error "temporarily disabled, please open on issue on https://github.com/commercialhaskell/stackage-server/issues/ if you need it"
     {-
     fullDeps <- (== Just "true") <$> lookupGetParam "full-deps"
     spec <- parseSnapshotSpec $ toPathPiece slug

--- a/src/Handler/StackageHome.hs
+++ b/src/Handler/StackageHome.hs
@@ -53,7 +53,8 @@ instance ToJSON SnapshotInfo where
 getStackageDiffR :: SnapName -> SnapName -> Handler TypedContent
 getStackageDiffR name1 name2 = track "Handler.StackageHome.getStackageDiffR" $ do
     cacheSeconds $ 60 * 60 * 48
-    Entity sid1 _ <- lookupSnapshot name1 >>= maybe notFound return
+    Entity sid1 prevSnap <- lookupSnapshot name1 >>= maybe notFound return
+    mprevprevSnapName <- map snd <$> snapshotBefore (snapshotName prevSnap)
     Entity sid2 _ <- lookupSnapshot name2 >>= maybe notFound return
     snapDiff <- getSnapshotDiff sid1 sid2
     selectRep $ do

--- a/src/Handler/StackageHome.hs
+++ b/src/Handler/StackageHome.hs
@@ -155,8 +155,8 @@ getStackageCabalConfigR name = track "Handler.StackageHome.getStackageCabalConfi
         toBuilder (pliName p) ++
         constraint p
 
-yearMonthDay :: FormatTime t => t -> String
-yearMonthDay = formatTime defaultTimeLocale "%Y-%m-%d"
+yearMonthDayTime :: FormatTime t => t -> String
+yearMonthDayTime = formatTime defaultTimeLocale "%Y-%m-%d %H:%M %Z"
 
 getSnapshotPackagesR :: SnapName -> Handler () -- FIXME move to OldLinks?
 getSnapshotPackagesR name = track "Handler.StackageHome.getSnapshotPackagesR" $

--- a/src/Handler/StackageHome.hs
+++ b/src/Handler/StackageHome.hs
@@ -97,7 +97,7 @@ getStackageCabalConfigR name = track "Handler.StackageHome.getStackageCabalConfi
         yield $ Chunk $ toBuilder '\n'
 
     revisionsWarning =
-        toBuilder (asText "-- NOTE: Due to revisions, this file may not work. See:\n-- https://github.com/fpco/stackage-server/issues/232\n\n")
+        toBuilder (asText "-- NOTE: Due to revisions, this file may not work. See:\n-- https://github.com/commercialhaskell/stackage-server/issues/232\n\n")
 
     headerGlobal render = yield $ Chunk $
         revisionsWarning ++

--- a/static/haddock/style.css
+++ b/static/haddock/style.css
@@ -311,7 +311,7 @@ div#style-menu-holder {
   display: none;
 }
 
-/* Fixes: https://github.com/fpco/stackage-server/issues/222 */
+/* Fixes: https://github.com/commercialhaskell/stackage-server/issues/222 */
 /* #synopsis { */
 /*   display: none; */
 /* } */

--- a/templates/default-layout.hamlet
+++ b/templates/default-layout.hamlet
@@ -13,7 +13,7 @@
             <li> <a href="/snapshots">Snapshots</a>
             <li> <a href="/lts">LTS</a>
             <li> <a href="/nightly">Nightly</a>
-            <li> <a href="https://github.com/fpco/stackage#frequently-asked-questions">FAQ</a>
+            <li> <a href="https://github.com/commercialhaskell/stackage#frequently-asked-questions">FAQ</a>
             <li> <a href="/blog">Blog</a>
 
 $maybe msg <- mmsg

--- a/templates/home.hamlet
+++ b/templates/home.hamlet
@@ -17,7 +17,7 @@
             <h3>Stable Haskell package sets
             <ul>
               <li>A distribution of compatible Haskell packages from <a href="https://hackage.haskell.org">Hackage</a> that build together
-              <li>Stackage is a community project: <a href="https://github.com/fpco/stackage/blob/master/MAINTAINERS.md#adding-a-package"><b>how to add packages to Stackage</b></a>
+              <li>Stackage is a community project: <a href="https://github.com/commercialhaskell/stackage/blob/master/MAINTAINERS.md#adding-a-package"><b>how to add packages to Stackage</b></a>
               <li><a href="https://haskellstack.org">stack</a> makes using Stackage easy
         <div .span6>
             $maybe post <- mrecentBlog
@@ -43,7 +43,7 @@
                 About Stackage
             <p>
                 Stackage provides consistent sets of Haskell packages, known to build together and pass their tests before becoming <a href="/nightly">Stackage Nightly</a> snapshots and <a href="/lts">LTS</a>
-                (<a href="https://github.com/fpco/lts-haskell#readme">Long Term Support</a>) releases.
+                (<a href="https://github.com/commercialhaskell/lts-haskell#readme">Long Term Support</a>) releases.
             <p>
                 It is a distribution of a subset of packages from <a href="https://hackage.haskell.org">Hackage</a>, each package chosen at a version to make the set self-consistent. Note that Stackage does not patch any packages.
             <p>
@@ -54,10 +54,10 @@
                 Stackage is a community project: Haskell users around the world work together to keep Stackage snapshots up to date with recent package versions:
                 Stackage itself and all the tools surrounding it are open-source.
                 See #
-                \<a href="https://github.com/fpco/stackage/blob/master/MAINTAINERS.md#adding-a-package"><b>how to add packages to Stackage</b></a>.
+                \<a href="https://github.com/commercialhaskell/stackage/blob/master/MAINTAINERS.md#adding-a-package"><b>how to add packages to Stackage</b></a>.
             <p>
                 Have more questions? We have a #
-                \<a href="https://github.com/fpco/stackage#frequently-asked-questions">FAQ section on Github</a>.
+                \<a href="https://github.com/commercialhaskell/stackage#frequently-asked-questions">FAQ section on Github</a>.
 
             <p>
                 Stackage's infrastructure, build machines, initial creation and ongoing maintenance were proudly sponsored by <a href="https://www.fpcomplete.com">FP Complete</a> from 2014 to 2024.

--- a/templates/hoogle.hamlet
+++ b/templates/hoogle.hamlet
@@ -5,7 +5,7 @@
         <p style="font-size:0.8em">
             <i>Note that Stackage only displays results for the latest LTS and Nightly snapshot.
             \ #
-            <a href="https://github.com/fpco/stackage-server/issues/305">Learn more.
+            <a href="https://github.com/commercialhaskell/stackage-server/issues/305">Learn more.
         ^{hoogleForm}
         $if null results
             <p>Your search produced no results.

--- a/templates/package.lucius
+++ b/templates/package.lucius
@@ -255,7 +255,7 @@ h2.changes-title {
   color: #fff;
 }
 
-/* https://github.com/fpco/stackage-server/issues/39 */
+/* https://github.com/commercialhaskell/stackage-server/issues/39 */
 div.plain-text {
   white-space: pre-wrap;
 }

--- a/templates/spam-package.hamlet
+++ b/templates/spam-package.hamlet
@@ -7,7 +7,7 @@
 
 <p>
   If you believe this is in error, please
-  <a href="https://github.com/fpco/stackage-content/edit/master/spam-packages.yaml">send a pull request
+  <a href="https://github.com/commercialhaskell/stackage-content/edit/master/spam-packages.yaml">send a pull request
   to remove this classification.
 
 <p>

--- a/templates/stackage-diff.hamlet
+++ b/templates/stackage-diff.hamlet
@@ -1,5 +1,10 @@
 <h1>Compare Stackage snapshots
 
+$maybe prevprev <- mprevprevSnapName
+  <div .snapshot-nav>
+    <a href=@{StackageDiffR prevprev name1}>
+      \< previous diff
+
 <div .container .content>
   <div .packages>
     <table .table>

--- a/templates/stackage-home.hamlet
+++ b/templates/stackage-home.hamlet
@@ -3,7 +3,7 @@ $newline never
     <h1>
         #{snapshotTitle snapshot}
     <p>
-        Published on #{yearMonthDay (snapshotCreated snapshot)}
+        Published on #{yearMonthDayTime (snapshotCreated snapshot)}
         <span .separator>
         <span>
             <a href=@{StackageDiffR previousSnapName name}>View changes


### PR DESCRIPTION
These 3 commits are unrelated but small and self-contained, so I thought easier to just combine in one PR:

- currently the date is shown for snapshots (which is mostly redundant for nightly snapshots), let's also include the time
- replace remaining references to `github.com/fpco/` with `github.com/commercialhaskell/`
- add a link on snapshot changes (diff) pages to the previous diff page, for easier navigation (main motivator for this PR)

Compiles fine but untested (since I don't have a local db setup)