### PR TITLE
remove unused (hackage) tarball handling code for StackageSdistR

### DIFF
--- a/src/Handler/PackageDeps.hs
+++ b/src/Handler/PackageDeps.hs
@@ -22,7 +22,7 @@ getPackageDepsR pname = do
 getSnapshotPackageDepsR :: SnapName -> PackageNameVersion -> Handler Html
 getSnapshotPackageDepsR snapName pnv = do
     cacheSeconds $ 60 * 60
-    pnvToSnapshotPackageInfo snapName pnv (\_ _ -> notFound) $ \isSameVersion spi ->
+    pnvToSnapshotPackageInfo snapName pnv $ \isSameVersion spi ->
         if isSameVersion
             then helper Deps spi
             else redirect $
@@ -40,7 +40,7 @@ getPackageRevDepsR pname = do
 getSnapshotPackageRevDepsR :: SnapName -> PackageNameVersion -> Handler Html
 getSnapshotPackageRevDepsR snapName pnv = do
     cacheSeconds $ 60 * 60
-    pnvToSnapshotPackageInfo snapName pnv (\_ _ -> notFound) $ \isSameVersion spi ->
+    pnvToSnapshotPackageInfo snapName pnv $ \isSameVersion spi ->
         if isSameVersion
             then helper RevDeps spi
             else redirect $

--- a/src/Handler/StackageSdist.hs
+++ b/src/Handler/StackageSdist.hs
@@ -8,24 +8,11 @@ import Import
 import Stackage.Database
 import Handler.Package (packagePage)
 
-handlePNVTarball :: PackageNameP -> VersionP -> Handler TypedContent
-handlePNVTarball name version =
-    redirect $
-    concat -- TODO: Should this be switched to HTTPS by now?
-                -- unfortunately using insecure HTTP for cabal's sake
-        [ "http://hackage.fpcomplete.com/package/"
-        , toPathPiece name
-        , "-"
-        , toPathPiece version
-        , ".tar.gz"
-        ]
-
-
 getStackageSdistR
   :: SnapName -> PackageNameVersion -> HandlerFor App TypedContent
 getStackageSdistR sname pnv =
     track "Handler.StackageSdist.getStackageSdistR" $
-    pnvToSnapshotPackageInfo sname pnv handlePNVTarball $ \isSameVersion spi ->
+    pnvToSnapshotPackageInfo sname pnv $ \isSameVersion spi ->
         if isSameVersion
             then packagePage (Just spi) (spiPackageName spi) >>= sendResponse
             else redirect $
@@ -36,17 +23,14 @@ getStackageSdistR sname pnv =
 pnvToSnapshotPackageInfo ::
        SnapName
     -> PackageNameVersion
-    -> (PackageNameP -> VersionP -> HandlerFor App b)
     -> (Bool -> SnapshotPackageInfo -> HandlerFor App b)
     -> HandlerFor App b
-pnvToSnapshotPackageInfo sname pnv tarballHandler spiHandler =
+pnvToSnapshotPackageInfo sname pnv spiHandler =
     case pnv of
         PNVName pname -> spiHelper sname pname >>= spiHandler False
         PNVNameVersion pname version ->
             spiHelper sname pname >>= \spi -> spiHandler (version == spiVersion spi) spi
-        PNVTarball name version -> tarballHandler name version
 
 
 spiHelper :: SnapName -> PackageNameP -> Handler SnapshotPackageInfo
 spiHelper sname pname = getSnapshotPackageInfo sname pname >>= maybe notFound return
-

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -180,8 +180,7 @@ newtype PackageSetIdent = PackageSetIdent { unPackageSetIdent :: Text }
 instance PersistFieldSql PackageSetIdent where
     sqlType = sqlType . fmap unPackageSetIdent
 
-data PackageNameVersion = PNVTarball !PackageNameP !VersionP
-                        | PNVNameVersion !PackageNameP !VersionP
+data PackageNameVersion = PNVNameVersion !PackageNameP !VersionP
                         | PNVName !PackageNameP
     deriving (Read, Show, Eq, Ord)
 
@@ -254,13 +253,8 @@ instance ToMarkup PackageVersionRev where
 
 
 instance PathPiece PackageNameVersion where
-    toPathPiece (PNVTarball x y) = T.concat [toPathPiece x, "-", toPathPiece y, ".tar.gz"]
     toPathPiece (PNVNameVersion x y) = T.concat [toPathPiece x, "-", toPathPiece y]
     toPathPiece (PNVName x) = toPathPiece x
-    fromPathPiece t'
-        | Just t <- T.stripSuffix ".tar.gz" t' = do
-            PackageIdentifierP name version <- fromPathPiece t
-            return $ PNVTarball name version
     fromPathPiece t =
         case T.breakOnEnd "-" t of
             ("", _) -> PNVName <$> fromPathPiece t


### PR DESCRIPTION
I noticed this code seems unused since
http://hackage.fpcomplete.com/package/ seems 404

So afaict this can be removed safely. Does anyone see a problem?