### PR TITLE
diff: add links to snapshots

### DIFF
--- a/templates/stackage-diff.hamlet
+++ b/templates/stackage-diff.hamlet
@@ -10,8 +10,8 @@ $maybe prevprev <- mprevprevSnapName
     <table .table>
       <thead>
         <tr>
-          <th>#{name1}
-          <th>#{name2}
+          <th><a href=@{SnapshotR name1 StackageHomeR}>#{name1}
+          <th><a href=@{SnapshotR name2 StackageHomeR}>#{name2}
       <tbody>
         $forall (pkgname, VersionChange verChange, versionDiff) <- toVersionedDiffList snapDiff
           <tr>


### PR DESCRIPTION
This makes the names of the two [diffed](https://www.stackage.org/diff/lts-23.22/lts-23.23) snapshots links to their respective pages.

```
<snapshot1/>                         <snapshot2/>
 s1diff1                              s2diff1
 s1diff2                              s2diff2
   :                                    :
```